### PR TITLE
Fix task splitting during project creation

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -122,7 +122,7 @@
 
 <footer class="page__footer section">
     <div class='inner'>
-        {{ 'Made by the' | translate }} <a href="https://www.hotosm.org/">HOTOSM</a> {{ 'Community, modified by' | translate }} <a href="https://www.kaart.com">Kaart</a>. <a href="/about">{{ 'Get in touch' | translate }}</a>.</span>
+        <span>{{ 'Made by the' | translate }} <a href="https://www.hotosm.org/">HOTOSM</a> {{ 'Community, modified by' | translate }} <a href="https://www.kaart.com">Kaart</a>. <a href="/about">{{ 'Get in touch' | translate }}</a>.</span>
         <span class="right">{{ 'Give feedback on' | translate }} <a href="https://github.com/KaartGroup/tasking-manager" target="_blank" rel="noopener">{{ 'GitHub' | translate }}</a>. {{ 'Learn more about' | translate }} <a href="https://www.openstreetmap.org/about">OpenStreetMap</a>.</span>
     </div>
 </footer>
@@ -159,8 +159,8 @@
 <script src="node_modules/ng-file-upload/dist/ng-file-upload.js"></script>
 <!-- /build -->
 
-<!-- build:js https://cdn.jsdelivr.net/npm/@turf/turf@5/turf.min.js -->
-<script src="node_modules/@turf/turf/turf.js"></script>
+<!-- build:js https://cdnjs.cloudflare.com/ajax/libs/Turf.js/3.0.14/turf.min.js -->
+<script src="node_modules/turf/turf.js"></script>
 <!-- /build -->
 
 <!-- build:js https://cdn.rawgit.com/calvinmetcalf/shapefile-js/gh-pages/dist/shp.min.js-->


### PR DESCRIPTION
I added a missing `<span>` and the Turf library uses what v3.4.3 is using.

Signed-off-by: Taylor Smock <taylor.smock@kaartgroup.com>