### PR TITLE
Simplify polygons for Mapillary tasks

### DIFF
--- a/server/services/mapillary_service.py
+++ b/server/services/mapillary_service.py
@@ -150,7 +150,7 @@ class MapillaryService:
             # if props:
             #     tasks.append(geojson.Feature(geometry=feature['geometry'], properties={'mapillary': props}))
 
-            geom = linemerge([shape(t['geometry']) for t in task])
+            geom = linemerge([shape(t['geometry']) for t in task]).simplify(0.00005) # Simplify uses degrees
             tasks.append(geojson.Feature(geometry=mapping(geom), properties={'mapillary': [t['properties']['key'] for t in task]}))
             features.remove(feature)
 


### PR DESCRIPTION
This has a significant reduction in the number of waypoints. This should drastically speed up various processes.

In my testing, somewhere between 1/9 and 1/5 of the points were left after simplification, without any real loss to geometry.