### PR TITLE
FIXUP: Avoid potential race between layer creation and import

### DIFF
--- a/client/app/project/project.controller.js
+++ b/client/app/project/project.controller.js
@@ -1702,24 +1702,12 @@
             changesetComment,
             customUrl) {
             if (taskCount > 1) {
-                // load a new empty layer in josm for task square(s).  This step required to get custom name for layer
-                // use empty, uri encoded osmxml with upload=never for the data para
-                var emptyTaskLayerParams = {
+                //load task square(s) into JOSM
+                var taskImportParams = {
                     new_layer: true,
                     mime_type: encodeURIComponent('application/x-osm+xml'),
                     layer_name: encodeURIComponent('Task Boundaries #' + vm.projectData.projectId + '- Do not edit or upload'),
-                    data: encodeURIComponent('<?xml version="1.0" encoding="utf8"?><osm generator="JOSM" upload="never" version="0.6"></osm>')
-                };
-                editorService.sendJOSMCmd('http://127.0.0.1:8111/load_data', emptyTaskLayerParams)
-                    .catch(function() {
-                        //warn that JSOM couldn't be started
-                        vm.editorStartError = 'josm-error';
-                    });
-
-                //load task square(s) into JOSM
-                var taskImportParams = {
                     url: editorService.getOSMXMLUrl(vm.projectData.projectId, vm.getSelectTaskIds()),
-                    new_layer: false
                 };
                 editorService.sendJOSMCmd('http://127.0.0.1:8111/import', taskImportParams)
                     .catch(function() {
@@ -1756,26 +1744,16 @@
 
             // load a new empty layer in josm for osm data, this step necessary to have a custom name for the layer
             // use empty, uri encoded osmxml for the data param
-            var emptyOSMLayerParams = {
+            var loadAndZoomParams = {
                 new_layer: true,
                 mime_type: 'application/x-osm+xml',
                 layer_name: 'OSM Data',
-                data: encodeURIComponent('<?xml version="1.0" encoding="utf8"?><osm generator="JOSM" version="0.6"></osm>')
-            }
-            editorService.sendJOSMCmd('http://127.0.0.1:8111/load_data', emptyOSMLayerParams)
-                .catch(function() {
-                    //warn that JSOM couldn't be started
-                    vm.editorStartError = 'josm-error';
-                });
-
-            var loadAndZoomParams = {
                 left: extentTransformed[0],
                 bottom: extentTransformed[1],
                 right: extentTransformed[2],
                 top: extentTransformed[3],
                 changeset_comment: encodeURIComponent(changesetComment),
-                changeset_source: encodeURIComponent(changesetSource),
-                new_layer: false
+                changeset_source: encodeURIComponent(changesetSource)
             };
 
             if (taskCount == 1) {
@@ -1815,21 +1793,11 @@
          * @param file
          */
         vm.loadProjectFile = function (file) {
-            var emptyTaskLayerParams = {
-                new_layer: true,
-                upload_policy: enumerateUploadPolicy(file.uploadPolicy),
+            var projectFileParams = {
                 layer_name: encodeURIComponent(file.fileName.replace(/\.[^/.]+$/,"")),
                 mime_type: encodeURIComponent('application/x-osm+xml'),
-                data: encodeURIComponent('<?xml version="1.0" encoding="utf8"?><osm generator="JOSM" version="0.6"></osm>')
-            }
-            editorService.sendJOSMCmd('http://127.0.0.1:8111/load_data', emptyTaskLayerParams)
-                .catch(function() {
-                    //warn that JSOM couldn't be started
-                    vm.editorStartError = 'josm-error';
-                });
-
-            var projectFileParams = {
-                new_layer: false,
+                new_layer: true,
+                upload_policy: enumerateUploadPolicy(file.uploadPolicy),
                 url: editorService.getProjectFileOSMXMLUrl(vm.projectData.projectId, vm.getSelectTaskIds(), file)
             }
             editorService.sendJOSMCmd('http://127.0.0.1:8111/import', projectFileParams)
@@ -2033,21 +2001,11 @@
          * @param file
          */
         vm.loadProjectFile = function (file) {
-            var emptyTaskLayerParams = {
+            var projectFileParams = {
                 new_layer: true,
                 upload_policy: enumerateUploadPolicy(file.uploadPolicy),
                 layer_name: encodeURIComponent(file.fileName.replace(/\.[^/.]+$/,"")),
                 mime_type: encodeURIComponent('application/x-osm+xml'),
-                data: encodeURIComponent('<?xml version="1.0" encoding="utf8"?><osm generator="JOSM" version="0.6"></osm>')
-            }
-            editorService.sendJOSMCmd('http://127.0.0.1:8111/load_data', emptyTaskLayerParams)
-                .catch(function() {
-                    //warn that JSOM couldn't be started
-                    vm.editorStartError = 'josm-error';
-                });
-
-            var projectFileParams = {
-                new_layer: false,
                 url: editorService.getProjectFileOSMXMLUrl(vm.projectData.projectId, vm.getSelectTaskIds(), file)
             }
             editorService.sendJOSMCmd('http://127.0.0.1:8111/import', projectFileParams)

--- a/client/app/project/project.controller.js
+++ b/client/app/project/project.controller.js
@@ -562,7 +562,7 @@
                 else {
                     vm.userCanMap, vm.userCanValidate, vm.showOSMCha = false;
                 }
-                
+
                 addAoiToMap(vm.projectData.areaOfInterest);
                 addPriorityAreasToMap(vm.projectData.priorityAreas);
                 addProjectTasksToMap(vm.projectData.tasks, true);
@@ -1794,20 +1794,11 @@
                 if (vm.currentTab === 'mapping' && vm.project_files.length > 0) {
                     var i;
                     for (i = 0; i < vm.project_files.length; i++) {
-                        var emptyTaskLayerParams = {
+                        var projectFileParams = {
+                            layer_name: encodeURIComponent(vm.project_files[i].fileName.replace(/\.[^/.]+$/,"")),
+                            mime_type: encodeURIComponent('application/x-osm+xml'),
                             new_layer: true,
                             upload_policy: enumerateUploadPolicy(vm.project_files[i].uploadPolicy),
-                            mime_type: encodeURIComponent('application/x-osm+xml'),
-                            layer_name: encodeURIComponent(vm.project_files[i].fileName.replace(/\.[^/.]+$/,"")),
-                            data: encodeURIComponent('<?xml version="1.0" encoding="utf8"?><osm generator="JOSM" version="0.6"></osm>')
-                        }
-                        editorService.sendJOSMCmd('http://127.0.0.1:8111/load_data', emptyTaskLayerParams)
-                            .catch(function() {
-                                //warn that JSOM couldn't be started
-                                vm.editorStartError = 'josm-error';
-                            });
-                        var projectFileParams = {
-                            new_layer: false,
                             url: editorService.getProjectFileOSMXMLUrl(vm.projectData.projectId, vm.getSelectTaskIds(), vm.project_files[i])
                         }
                         editorService.sendJOSMCmd('http://127.0.0.1:8111/import', projectFileParams)

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -387,7 +387,7 @@ class Project(db.Model):
         stats_dto.total_time_spent = 0
 
         query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                   WHERE action='LOCKED_FOR_MAPPING'
+                   WHERE (action='LOCKED_FOR_MAPPING' or action='AUTO_UNLOCKED_FOR_MAPPING')
                    and user_id = :user_id and project_id = :project_id;"""
         total_mapping_time = db.engine.execute(text(query), user_id=user_id, project_id=self.id)
         for time in total_mapping_time:
@@ -397,7 +397,7 @@ class Project(db.Model):
                 stats_dto.total_time_spent += stats_dto.time_spent_mapping
 
         query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                   WHERE action='LOCKED_FOR_VALIDATION'
+                   WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
                    and user_id = :user_id and project_id = :project_id;"""
         total_validation_time = db.engine.execute(text(query), user_id=user_id, project_id=self.id)
         for time in total_validation_time:
@@ -453,7 +453,8 @@ class Project(db.Model):
         project_stats.average_validation_time = 0
 
         query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                   WHERE action='LOCKED_FOR_MAPPING' and project_id = :project_id;"""
+                   WHERE (action='LOCKED_FOR_MAPPING' or action='AUTO_UNLOCKED_FOR_MAPPING')
+                   and project_id = :project_id;"""
         total_mapping_time = db.engine.execute(text(query), project_id=self.id)
         for row in total_mapping_time:
             total_mapping_time = row[0]
@@ -466,7 +467,8 @@ class Project(db.Model):
                     project_stats.average_mapping_time = average_mapping_time
 
         query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                   WHERE action='LOCKED_FOR_VALIDATION' and project_id = :project_id;"""
+                   WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
+                   and project_id = :project_id;"""
         total_validation_time = db.engine.execute(text(query), project_id=self.id)
         for row in total_validation_time:
             total_validation_time = row[0]

--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -114,7 +114,7 @@ class User(db.Model):
 
 
     @staticmethod
-    def filter_users(user_filter: str, project_id: int, page: int, 
+    def filter_users(user_filter: str, project_id: int, page: int,
                      is_project_manager:bool=False) -> UserFilterDTO:
         """ Finds users that matches first characters, for auto-complete.
 
@@ -130,7 +130,7 @@ class User(db.Model):
             query = query.filter(User.role.in_([UserRole.ADMIN.value, UserRole.PROJECT_MANAGER.value]))
 
         results = query.paginate(page, 20, True)
-            
+
         if results.total == 0:
             raise NotFound()
 
@@ -272,7 +272,7 @@ class User(db.Model):
         user_dto.time_spent_validating = 0
 
         sql = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                WHERE action='LOCKED_FOR_VALIDATION'
+                WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
                 and user_id = :user_id;"""
         total_validation_time = db.engine.execute(text(sql), user_id=self.id)
         for row in total_validation_time:
@@ -283,7 +283,7 @@ class User(db.Model):
                 user_dto.total_time_spent += user_dto.time_spent_validating
 
         sql = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                WHERE action='LOCKED_FOR_MAPPING'
+                WHERE (action='LOCKED_FOR_MAPPING' or action='AUTO_UNLOCKED_FOR_MAPPING')
                 and user_id = :user_id;"""
         total_mapping_time = db.engine.execute(text(sql), user_id=self.id)
         for row in total_mapping_time:

--- a/server/services/users/user_service.py
+++ b/server/services/users/user_service.py
@@ -129,7 +129,7 @@ class UserService:
         stats_dto.time_spent_validating = 0
 
         sql = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                WHERE action='LOCKED_FOR_VALIDATION'
+                WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
                 and user_id = :user_id;"""
         total_validation_time = db.engine.execute(text(sql), user_id=user.id)
         for time in total_validation_time:
@@ -139,7 +139,7 @@ class UserService:
                 stats_dto.total_time_spent += stats_dto.time_spent_validating
 
         sql = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                WHERE action='LOCKED_FOR_MAPPING'
+                WHERE (action='LOCKED_FOR_MAPPING' or action='AUTO_UNLOCKED_FOR_MAPPING')
                 and user_id = :user_id;"""
         total_mapping_time = db.engine.execute(text(sql), user_id=user.id)
         for time in total_mapping_time:
@@ -175,7 +175,7 @@ class UserService:
 
     @staticmethod
     @cached(user_filter_cache)
-    def filter_users(username: str, project_id: int, 
+    def filter_users(username: str, project_id: int,
                      page: int, is_project_manager: bool = False) -> UserFilterDTO:
         """ Gets paginated list of users, filtered by username, for autocomplete """
         return User.filter_users(username, project_id, page, is_project_manager)


### PR DESCRIPTION
* This should avoid situations where a layer is created via remote
  control but is not yet available for the next remote control which
  adds a layer to import.

Signed-off-by: Taylor Smock <taylor.smock@kaart.com>